### PR TITLE
add description to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bfd-ui",
   "version": "1.5.9",
-  "description": "",
+  "description": "企业级 React 组件库 🚀",
   "main": "index.js",
   "scripts": {
     "test": "npm run lint && npm run unit",


### PR DESCRIPTION
this info is exposed on yarnpkg.com, npmjs.com and others. If it's not filled in, the first part of the readme is used (which causes duplication)

Sorry I can't speak Chinese